### PR TITLE
updated test_has_docstring to skip modules

### DIFF
--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -3,9 +3,9 @@ import pytest
 
 def test_has_docstring(obj):
     """Check if an object has a docstring."""
-    doc = inspect.getdoc(obj)
     if inspect.ismodule(obj):
-        msg = f"{obj.__name__} has no docstring."
-    else:
-        msg = f"{obj.__module__}.{obj.__qualname__} has no docstring."
+        return # modules do not require docstrings
+    
+    doc = inspect.getdoc(obj)
+    msg = f"{obj.__module__}.{obj.__qualname__} has no docstring."
     assert doc is not None, msg


### PR DESCRIPTION
Module docstrings are often redundant boilerplate and don't look that good on sphinx -- skipping check for these.